### PR TITLE
Fix input references after rename in #31

### DIFF
--- a/app/controllers/brainstorms_controller.rb
+++ b/app/controllers/brainstorms_controller.rb
@@ -34,9 +34,8 @@ class BrainstormsController < ApplicationController
   def show
     @ideas = @brainstorm.ideas
     @idea  = @ideas.new
+
     @current_facilitator = @facilitation.facilitated_by_session?(@session_id)
-    @current_facilitator_name   = @facilitation.facilitator_name
-    @current_user_name = REDIS.get(@session_id)
 
     @voting = Session::Voting.new(@brainstorm, @session_id)
   end
@@ -142,10 +141,6 @@ class BrainstormsController < ApplicationController
 
     def facilitated_by_session?(session_id)
       facilitator.value == session_id
-    end
-
-    def facilitator_name
-      Kredis.proxy(facilitator.value).get
     end
 
     private

--- a/app/controllers/brainstorms_controller.rb
+++ b/app/controllers/brainstorms_controller.rb
@@ -34,9 +34,9 @@ class BrainstormsController < ApplicationController
   def show
     @ideas = @brainstorm.ideas
     @idea  = @ideas.new
-
     @current_facilitator = @facilitation.facilitated_by_session?(@session_id)
-    @current_user_name   = @facilitation.facilitator_name
+    @current_facilitator_name   = @facilitation.facilitator_name
+    @current_user_name = REDIS.get(@session_id)
 
     @voting = Session::Voting.new(@brainstorm, @session_id)
   end
@@ -135,7 +135,6 @@ class BrainstormsController < ApplicationController
     def brainstorm_stage
       @brainstorm_stage ||= Kredis.enum("brainstorm_state_#{@brainstorm.token}", values: %i[ setup ideation vote voting_done ], default: nil)
     end
-
 
     def facilitator_session_id=(session_id)
       facilitator.value = session_id

--- a/app/controllers/brainstorms_controller.rb
+++ b/app/controllers/brainstorms_controller.rb
@@ -143,6 +143,10 @@ class BrainstormsController < ApplicationController
       facilitator.value == session_id
     end
 
+    def facilitator_name
+      Kredis.proxy(facilitator.value).get
+    end
+
     private
 
     def facilitator

--- a/app/models/brainstorm.rb
+++ b/app/models/brainstorm.rb
@@ -1,5 +1,5 @@
 class Brainstorm < ApplicationRecord
-  include Facilitated
+  include Facilitated, States
 
   has_many :ideas
   attr_accessor :name

--- a/app/models/brainstorm.rb
+++ b/app/models/brainstorm.rb
@@ -1,4 +1,6 @@
 class Brainstorm < ApplicationRecord
+  include Facilitated
+
   has_many :ideas
   attr_accessor :name
 

--- a/app/models/brainstorm/facilitated.rb
+++ b/app/models/brainstorm/facilitated.rb
@@ -1,0 +1,15 @@
+module Brainstorm::Facilitated
+  def facilitator_session_id=(session_id)
+    facilitator_session_id.value = session_id
+  end
+
+  def facilitator
+    @facilitator ||= Session.new(facilitator_session_id.value)
+  end
+
+  private
+
+  def facilitator_session_id
+    @facilitator_session_id ||= Kredis.string("brainstorm_facilitator_#{token}")
+  end
+end

--- a/app/models/brainstorm/states.rb
+++ b/app/models/brainstorm/states.rb
@@ -1,0 +1,17 @@
+module Brainstorm::States
+  extend ActiveSupport::Concern
+
+  STATES = %i[ setup ideation vote voting_done ]
+
+  included do
+    kredis_enum :state_proxy, key: ->(b) { "brainstorm_state_#{b.token}" }, values: STATES, default: nil
+  end
+
+  def state
+    state_proxy.value
+  end
+
+  def state=(state)
+    state_proxy.value = state
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,4 +1,6 @@
 class Session
+  attr_reader :id
+
   def initialize(id)
     @id, @name_proxy = id, Kredis.string(id)
   end
@@ -13,5 +15,5 @@ class Session
 
   private
 
-  attr_reader :id, :name_proxy
+  attr_reader :name_proxy
 end

--- a/app/views/brainstorms/_setup_participant.html.erb
+++ b/app/views/brainstorms/_setup_participant.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="flex flex-col bg-light-yellowy justify-between w-full lg:w-3/4 mt-12 my-shadow-lg">
     <div class="bg-dots-bigger h-10"></div>
-    <p class="text-blurple text-6xl lg:text-4xl italic font-medium px-20 py-12 text-center">Waiting for <span class="font-bold"><%=@facilitation.facilitator_name %></span> to start the brainstorm</p>
+    <p class="text-blurple text-6xl lg:text-4xl italic font-medium px-20 py-12 text-center">Waiting for <span class="font-bold"><%= @brainstorm.facilitator.name %></span> to start the brainstorm</p>
   </div>
   <div class="bg-blurple w-full lg:w-3/4 mt-16">
     <p class="text-white text-5xl lg:text-3xl italic font-semibold w-full pb-16 pt-16 lg:pb-64 text-center">A few simple steps for this brainstorm</p>

--- a/app/views/brainstorms/show.html.erb
+++ b/app/views/brainstorms/show.html.erb
@@ -27,7 +27,7 @@
 <script>
   currentUser = {
     id: '<%= @session_id %>',
-    currentUserName: '<%= @current_user_name %>',
+    currentUserName: '<%= @session.name %>',
     facilitator: '<%= @current_facilitator %>',
     votesCastIdeas: new Set(<%= @voting.idea_votes.members %>),
     votesCastIdeaBuilds: new Set(<%= @voting.idea_build_votes.members %>),

--- a/app/views/brainstorms/show.html.erb
+++ b/app/views/brainstorms/show.html.erb
@@ -35,7 +35,7 @@
   };
 
   brainstormStore = {
-    state: '<%= @facilitation.brainstorm_stage.value %>',
+    state: '<%= @brainstorm.state %>',
     maxVotesPerUser: '<%= Session::Voting::MAX_VOTES_PER_SESSION %>'
   };
 

--- a/app/views/brainstorms/show.html.erb
+++ b/app/views/brainstorms/show.html.erb
@@ -43,7 +43,7 @@
     if (!currentUser.currentUserName || currentUser.currentUserName == "Anonymous Brainstormer") {
       document.getElementById("modalContainer").classList.remove("hidden");
       document.getElementById("modalContainer").setAttribute("x-data", "{ 'showModal': true }");
-      document.getElementById("set_user_name_user_name").setAttribute("value", createRandomUserName());
+      document.getElementById("session_name").setAttribute("value", createRandomUserName());
     }
   }
 

--- a/app/views/sessions/names/update.js.erb
+++ b/app/views/sessions/names/update.js.erb
@@ -1,1 +1,1 @@
-document.getElementById("set_user_name_user_name").value=currentUser.currentUserName
+document.getElementById("session_name").value = currentUser.currentUserName


### PR DESCRIPTION
Forgot to check if we relied on the `id` of `set_user_name_user_name` anywhere when I updated the form. We did in two places!